### PR TITLE
Fix ReDoS by limiting digit matches

### DIFF
--- a/lib/time-span.js
+++ b/lib/time-span.js
@@ -34,8 +34,8 @@ var msecPerSecond = 1000,
 //
 // ### Timespan Parsers
 //
-var timeSpanWithDays = /^(\d+):(\d+):(\d+):(\d+)(\.\d+)?/,
-    timeSpanNoDays = /^(\d+):(\d+):(\d+)(\.\d+)?/;
+var timeSpanWithDays = /^(\d{1,16}):(\d{1,16}):(\d{1,16}):(\d{1,16})(\.\d{1,16})?/,
+    timeSpanNoDays = /^(\d{1,16}):(\d{1,16}):(\d{1,16})(\.\d{1,16})?/;
 
 //
 // ### function TimeSpan (milliseconds, seconds, minutes, hours, days)
@@ -165,7 +165,7 @@ exports.parse = function (str) {
 //
 var parsers = {
   'milliseconds': {
-    exp: /(\d+)milli(?:second)?[s]?/i,
+    exp: /(\d{1,16})milli(?:second)?[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'milliseconds',
@@ -175,7 +175,7 @@ var parsers = {
     }
   },
   'seconds': {
-    exp: /(\d+)second[s]?/i,
+    exp: /(\d{1,16})second[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'seconds',
@@ -185,7 +185,7 @@ var parsers = {
     }
   },
   'minutes': {
-    exp: /(\d+)minute[s]?/i,
+    exp: /(\d{1,16})minute[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'minutes',
@@ -195,7 +195,7 @@ var parsers = {
     }
   },
   'hours': {
-    exp: /(\d+)hour[s]?/i,
+    exp: /(\d{1,16})hour[s]?/i,
     compute: function (delta, computed) {
       return _compute(delta, computed, {
         current: 'hours',
@@ -205,7 +205,7 @@ var parsers = {
     }
   },
   'days': {
-    exp: /(\d+)day[s]?/i,
+    exp: /(\d{1,16})day[s]?/i,
     compute: function (delta, computed) {
       var days     = monthDays(computed.months, computed.years),
           sign     = delta >= 0 ? 1 : -1,
@@ -249,7 +249,7 @@ var parsers = {
     }
   },
   'months': {
-    exp: /(\d+)month[s]?/i,
+    exp: /(\d{1,16})month[s]?/i,
     compute: function (delta, computed) {
       var round = delta > 0 ? Math.floor : Math.ceil;
       if (delta) { 
@@ -266,7 +266,7 @@ var parsers = {
     }
   },
   'years': {
-    exp: /(\d+)year[s]?/i,
+    exp: /(\d{1,16})year[s]?/i,
     compute: function (delta, computed) {
       if (delta) { computed.years += delta; }
       return computed;
@@ -321,7 +321,7 @@ exports.parseDate = function (str) {
   // of the target `str` to parse.
   //
   parserNames.forEach(function (group) {
-    zulu += '(\\d+[a-zA-Z]+)?';
+    zulu += '(\\d{1,16}[a-zA-Z]+)?';
   });
   
   if (/^NOW/i.test(str)) {


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-timespan.js

### ⚙️ Description *

No limitation in input size inside Regex makes it vulnerable to **ReDoS** (Regex Denial of Service) which can cause a slowdown (for 50,000 characters around 10 seconds matching time).

### 💻 Technical Description *

The Regex implementations used are vulnerable to ReDoS as they check for digits with no limits:

```javascript
(\d+)
```

This can be fixed with limiting the digit matches of the Regex pattern.

### 🐛 Proof of Concept (PoC) *

> The following regular expressions used for parsing the dates are vulnerable to ReDoS:
>
> ```
> /(\d+)milli(?:second)?[s]?/i
> /(\d+)second[s]?/i
> ...
> ```
> 
> The slowdown is relatively large when combining the slowdown produced by all the regex (for 50,000 characters around 10 
> seconds matching time).

**Ref:** https://github.com/indexzero/TimeSpan.js/issues/10

### 🔥 Proof of Fix (PoF) *

As the author of https://github.com/indexzero/TimeSpan.js/issues/10#issue-255877460 suggests, I've implemented a digit limit for the Regex (`MAX_SAFE_INTEGER`).

```javascript
(\d{1,16})
```

### 👍 User Acceptance Testing (UAT)

_Changed the Regex pattern, no breaking changes have been introduced._
